### PR TITLE
S3 racing preparations

### DIFF
--- a/src/LogicTests.test.ts
+++ b/src/LogicTests.test.ts
@@ -543,4 +543,18 @@ describe('full logic tests', () => {
         updateSettings('random-start-entrance', 'Any');
         expect(readSelector(totalCountersSelector).numExitsAccessible).toBe(1);
     });
+
+    it('does not consider banned crystals in semilogic', () => {
+        updateSettingsWithReset('starting-crystal-packs', 3);
+        store.dispatch(clickItem({ item: 'Progressive Beetle', take: false }));
+        store.dispatch(clickItem({ item: 'Clawshots', take: false }));
+        
+        const bat30Check = findCheckId("Batreaux's House", '30 Crystals');
+        expect(checkState(bat30Check)).toBe('semiLogic');
+
+        updateSettings('excluded-locations', [
+            "Upper Skyloft - Crystal in Link's Room",
+        ]);
+        expect(checkState(bat30Check)).toBe('outLogic');
+    });
 });

--- a/src/LogicTests.test.ts
+++ b/src/LogicTests.test.ts
@@ -42,11 +42,19 @@ describe('full logic tests', () => {
     beforeAll(async () => {
         store = createStore();
 
-        const loader = async (fileName: string) =>
-            await fs.promises.readFile(`./testData/${fileName}.yaml`, 'utf-8');
+        const loader = async (fileName: string) => {
+            if (fileName.includes('presets')) {
+                return "{}";
+            }
+            return await fs.promises.readFile(
+                `./testData/${fileName}`,
+                'utf-8',
+            );
+        }
+            
         const [logic, options] = await getAndPatchLogic(loader);
         defaultSet = defaultSettings(options);
-        store.dispatch(loadLogic({ logic, options, remote: main, remoteName: 'ssrando/main' }));
+        store.dispatch(loadLogic({ logic, options, presets: {}, remote: main, remoteName: 'ssrando/main' }));
     });
 
     // Before each test, must reset our tracker to default

--- a/src/Options.tsx
+++ b/src/Options.tsx
@@ -113,7 +113,7 @@ export type LogicOption =
 const optionCategorization: Record<string, readonly LogicOption[]> =
     optionCategorization_;
 
-const wellKnownRemotes = [LATEST_STRING, 'ssrando/main'];
+const wellKnownRemotes = [LATEST_STRING, 'YourAverageLink/pre-s3', 'ssrando/main'];
 
 /**
  * The default landing page for the tracker. Allows choosing logic source, permalink, and settings,
@@ -270,14 +270,15 @@ function useRemoteOptions() {
     const githubReleases = useReleases();
 
     return useMemo(() => {
-
         const niceRemoteName = (remote: string) => {
             if (remote === LATEST_STRING) {
                 return githubReleases
-                    ? `${githubReleases.latest} (Latest Stable Release)`
+                    ? `Latest Stable Release (${githubReleases.latest})`
                     : `Latest Stable Release`;
             } else if (remote === 'ssrando/main') {
-                return `${remote} (Latest Development Build)`;
+                return `Latest Development Build (${remote})`;
+            } else if (remote === 'YourAverageLink/pre-s3') {
+                return `Season 3 Racing Prerelease (${remote})`;
             }
     
             return remote;
@@ -337,13 +338,17 @@ function LogicChooser({
         <div className="optionsCategory logicChooser">
             <legend>
                 Randomizer Version
-                {loadedRemoteName && `: ${loadedRemoteName}`}
+                {activeOption
+                    ? `: ${activeOption.label}`
+                    : loadedRemoteName && `: ${loadedRemoteName}`}
             </legend>
             <Tabs
                 defaultActiveKey="wellKnown"
                 onSelect={(e) => {
                     if (e === 'raw') {
-                        inputRef.current?.setInput(formatRemote(selectedRemote));
+                        inputRef.current?.setInput(
+                            formatRemote(selectedRemote),
+                        );
                     }
                 }}
             >

--- a/src/OptionsPresets.tsx
+++ b/src/OptionsPresets.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useState } from 'react';
+import React, { CSSProperties, useMemo, useState } from 'react';
 import { OptionsAction } from './OptionsReducer';
 import { AllTypedOptions } from './permalink/SettingsTypes';
 import { LogicBundle } from './logic/slice';
@@ -6,8 +6,8 @@ import { Button, Modal } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState, useAppDispatch } from './store/store';
 import { Preset, addPreset, removePreset } from './saves/slice';
-import { formatRemote } from './loader/LogicLoader';
-import { encodePermalink } from './permalink/Settings';
+import { formatRemote, RemoteReference } from './loader/LogicLoader';
+import { encodePermalink, validateSettings } from './permalink/Settings';
 import { useSyncSavesToLocalStorage } from './LocalStorage';
 
 export function OptionsPresets({
@@ -38,6 +38,17 @@ export function OptionsPresets({
     );
 }
 
+function permaifyRelease(
+    logic: LogicBundle,
+): Exclude<RemoteReference, { type: 'latestRelease' }> {
+    return logic.remote.type === 'latestRelease'
+        ? {
+              type: 'releaseVersion',
+              versionTag: logic.remoteName,
+          }
+        : logic.remote;
+}
+
 function PresetsModal({
     currentLogic,
     currentSettings,
@@ -52,6 +63,27 @@ function PresetsModal({
     onHide: () => void;
 }) {
     const presets = useSelector((state: RootState) => state.saves.presets);
+    const remotePresets: Preset[] | undefined = useMemo(
+        () =>
+            currentLogic &&
+            Object.entries(currentLogic?.presets).map(([name, data]) => {
+                const validatedSettings = validateSettings(
+                    currentLogic.options,
+                    data,
+                );
+                return {
+                    id: `remote-${name}`,
+                    name,
+                    remote: permaifyRelease(currentLogic),
+                    settings: validatedSettings,
+                    visualPermalink: encodePermalink(
+                        currentLogic.options,
+                        validatedSettings,
+                    ),
+                } satisfies Preset;
+            }),
+        [currentLogic],
+    );
 
     return (
         <Modal show={show} onHide={onHide}>
@@ -62,6 +94,7 @@ function PresetsModal({
             </Modal.Header>
             <Modal.Body className="show-grid">
                 <div style={{ display: 'flex', flexFlow: 'column nowrap' }}>
+                    {remotePresets?.map((p) => (<PresetRow preset={p} isRemotePreset dispatch={dispatch} key={p.id} onHide={onHide} />))}
                     {presets.map((p) => (<PresetRow preset={p} dispatch={dispatch} key={p.id} onHide={onHide} />))}
                     {currentLogic && currentSettings && <AddPresetRow currentLogic={currentLogic} currentSettings={currentSettings} />}
                 </div>
@@ -77,10 +110,12 @@ function PresetRow({
     preset,
     dispatch,
     onHide,
+    isRemotePreset,
 }: {
     preset: Preset;
     dispatch: React.Dispatch<OptionsAction>;
     onHide: () => void;
+    isRemotePreset?: boolean;
 }) {
     const appDispatch = useAppDispatch();
     return (
@@ -99,18 +134,20 @@ function PresetRow({
         >
             <div style={{ display: 'flex', flexFlow: 'nowrap' }}>
                 {preset.name}
-                <div style={{ marginLeft: 'auto' }}>
-                    <Button
-                        onClick={(e) => {
-                            if (confirm(`Delete Preset ${preset.name}?`)) {
-                                appDispatch(removePreset(preset.id));
-                            }
-                            e.stopPropagation();
-                        }}
-                    >
-                        🗑️
-                    </Button>
-                </div>
+                {!isRemotePreset && (
+                    <div style={{ marginLeft: 'auto' }}>
+                        <Button
+                            onClick={(e) => {
+                                if (confirm(`Delete Preset ${preset.name}?`)) {
+                                    appDispatch(removePreset(preset.id));
+                                }
+                                e.stopPropagation();
+                            }}
+                        >
+                            🗑️
+                        </Button>
+                    </div>
+                )}
             </div>
             <div style={{ fontSize: '12px', whiteSpace: 'nowrap' }}>
                 {formatRemote(preset.remote)}
@@ -148,13 +185,7 @@ function AddPresetRow({
                 dispatch(
                     addPreset({
                         name,
-                        remote:
-                            currentLogic.remote.type === 'latestRelease'
-                                ? {
-                                    type: 'releaseVersion',
-                                    versionTag: currentLogic.remoteName,
-                                }
-                                : currentLogic.remote,
+                        remote: permaifyRelease(currentLogic),
                         settings: currentSettings,
                         visualPermalink: encodePermalink(
                             currentLogic.options,

--- a/src/OptionsReducer.ts
+++ b/src/OptionsReducer.ts
@@ -13,7 +13,7 @@ import { RemoteReference, loadRemoteLogic } from './loader/LogicLoader';
 import { getStoredRemote } from './LocalStorage';
 import { withCancel } from './utils/CancelToken';
 import _ from 'lodash';
-import { RawLogic } from './logic/UpstreamTypes';
+import { RawLogic, RawPresets } from './logic/UpstreamTypes';
 import { delay } from './utils/Promises';
 
 const defaultUpstream: RemoteReference = {
@@ -145,7 +145,7 @@ function convertError(e: unknown) {
 
 async function loadRemote(
     remote: RemoteReference,
-): Promise<[RawLogic, OptionDefs, string] | string> {
+): Promise<[RawLogic, OptionDefs, RawPresets, string] | string> {
     try {
         return await loadRemoteLogic(remote);
     } catch (e) {
@@ -194,12 +194,13 @@ export function useOptionsState() {
                             error: result,
                         });
                     } else {
-                        const [logic, options, remoteName] = result;
+                        const [logic, options, presets, remoteName] = result;
                         setLoadingState(undefined);
                         setLoadedBundle({
                             logic,
                             options,
                             remote: state.selectedRemote,
+                            presets,
                             remoteName,
                         });
                     }

--- a/src/locationTracker/Location.tsx
+++ b/src/locationTracker/Location.tsx
@@ -9,10 +9,11 @@ import '../locationTracker/Location.css';
 import { useEntrancePath, useTooltipExpr } from '../tooltips/TooltipHooks';
 import RequirementsTooltip from './RequirementsTooltip';
 import { useDispatch, useSelector } from 'react-redux';
-import { checkHintSelector, checkSelector } from '../tracker/selectors';
+import { checkHintSelector, checkSelector, isCheckBannedSelector } from '../tracker/selectors';
 import { clickCheck } from '../tracker/slice';
 import PathTooltip from './PathTooltip';
 import Tooltip from '../additionalComponents/Tooltip';
+import { RootState } from '../store/store';
 
 export interface LocationContextMenuProps {
     checkId: string;
@@ -25,6 +26,7 @@ export default function Location({
 }) {
     const dispatch = useDispatch();
     const hintItem = useSelector(checkHintSelector(id));
+    const isBanned = useSelector((state: RootState) => isCheckBannedSelector(state)(id));
 
     const check = useSelector(checkSelector(id));
 
@@ -60,6 +62,12 @@ export default function Location({
             <>
                 <RequirementsTooltip requirements={expr} />
                 {path && <><hr /><PathTooltip segments={path} /></>}
+                {isBanned && (
+                    <span style={{ color: 'grey', fontStyle: 'italic' }}>
+                        This location is excluded by current settings and
+                        will never be logically required.
+                    </span>
+                )}
             </>
         }>
             <div

--- a/src/logic/SemiLogic.ts
+++ b/src/logic/SemiLogic.ts
@@ -48,6 +48,7 @@ export function getAllTricksEnabledRequirements(
 
 export function computeSemiLogic(
     logic: Logic,
+    isCheckBanned: (checkId: string) => boolean,
     checkedChecks: Set<string>,
     inventory: Record<InventoryItem, number>,
     inLogicBits: BitVector,
@@ -66,6 +67,7 @@ export function computeSemiLogic(
     while (
         semiLogicStep(
             logic,
+            isCheckBanned,
             dungeonKeyLogic,
             settingsRequirements,
             semiLogicState,
@@ -89,6 +91,7 @@ export function computeSemiLogic(
     while (
         semiLogicStep(
             logic,
+            isCheckBanned,
             dungeonKeyLogic,
             settingsRequirementsWithTricks,
             semiLogicState,
@@ -103,6 +106,7 @@ export function computeSemiLogic(
 
 function semiLogicStep(
     logic: Logic,
+    isCheckBanned: (checkId: string) => boolean,
     dungeonKeyLogic: PotentialLocations[],
     settingsRequirements: Requirements,
     state: SemiLogicState,
@@ -134,7 +138,8 @@ function semiLogicStep(
         if (state.semiLogicBits.test(logic.itemBits[checkId])) {
             if (
                 checkDef.type === 'loose_crystal' &&
-                !state.assumedChecks.has(checkId)
+                !state.assumedChecks.has(checkId) &&
+                !isCheckBanned(checkId)
             ) {
                 state.assumedChecks.add(checkId);
                 changed = true;

--- a/src/logic/ThingsThatWouldBeNiceToHaveInTheDump.ts
+++ b/src/logic/ThingsThatWouldBeNiceToHaveInTheDump.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {
     OptionType,
     OptionValue,
@@ -72,13 +73,25 @@ export const swordsToAdd = {
     'True Master Sword': 6,
 };
 
-export const knownNoGossipStoneHintDistros = [
-    '2D Dowsing & Fi Hints',
-    'Boss Keysanity Fi Hints',
-    'Dowsing & Fi Hints',
-    'Remlits Tournament',
-    'Strong Dowsing All Dungeons',
+const s3RacingBannedGossipStones = [
+    'Gossip Stone in Shipyard',
+    'Gossip Stone in Temple of Time Area',
+    'Gossip Stone in Lower Platform Cave',
+    'Gossip Stone in Upper Platform Cave',
 ];
+const isS3RacingGossipStone = (stoneId: string) =>
+    !s3RacingBannedGossipStones.some((s) => stoneId.includes(s));
+
+export const doesHintDistroUseGossipStone: Record<string, ((stoneId: string) => boolean) | undefined> = {
+    '2D Dowsing & Fi Hints': _.stubFalse,
+    'Boss Keysanity Fi Hints': _.stubFalse,
+    'Dowsing & Fi Hints': _.stubFalse,
+    'Remlits Tournament': _.stubFalse,
+    'Strong Dowsing All Dungeons': _.stubFalse,
+    'Pre-S3 Base': isS3RacingGossipStone,
+    'Pre-S3 Variant': isS3RacingGossipStone,
+};
+
 
 // These requirements are populated based on required dungeons
 

--- a/src/logic/UpstreamTypes.ts
+++ b/src/logic/UpstreamTypes.ts
@@ -1,3 +1,5 @@
+import { OptionValue } from "../permalink/SettingsTypes";
+
 export enum TimeOfDay {
     DayOnly = 1,
     NightOnly = 2,
@@ -67,4 +69,8 @@ export interface RawLogic {
     dungeon_completion_requirements: {
         [dungeon: string]: string,
     }
+}
+
+export interface RawPresets {
+    [presetName: string]: Record<string, OptionValue>;
 }

--- a/src/logic/slice.ts
+++ b/src/logic/slice.ts
@@ -1,6 +1,6 @@
 import { OptionDefs } from '../permalink/SettingsTypes';
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
-import { RawLogic } from './UpstreamTypes';
+import { RawLogic, RawPresets } from './UpstreamTypes';
 import { RemoteReference } from '../loader/LogicLoader';
 
 /**
@@ -11,6 +11,8 @@ export interface LogicBundle {
     logic: RawLogic;
     /** options.yaml */
     options: OptionDefs;
+    /** gui/presets/default_presets.json */
+    presets: RawPresets;
     /** the remote we loaded from */
     remote: RemoteReference;
     /** the human-readable data (for Latest version, this is the latest) */

--- a/src/tracker/selectors.ts
+++ b/src/tracker/selectors.ts
@@ -552,7 +552,7 @@ export const areaHiddenSelector = createSelector(
     },
 );
 
-const isCheckBannedSelector = createSelector(
+export const isCheckBannedSelector = createSelector(
     [
         logicSelector,
         areaNonprogressSelector,

--- a/src/tracker/selectors.ts
+++ b/src/tracker/selectors.ts
@@ -9,11 +9,11 @@ import { RootState } from '../store/store';
 import { currySelector } from '../utils/redux';
 import {
     completeTriforceReq,
+    doesHintDistroUseGossipStone,
     gotOpeningReq,
     gotRaisingReq,
     hordeDoorReq,
     impaSongCheck,
-    knownNoGossipStoneHintDistros,
     runtimeOptions,
     swordsToAdd,
 } from '../logic/ThingsThatWouldBeNiceToHaveInTheDump';
@@ -619,24 +619,24 @@ const isCheckBannedSelector = createSelector(
             return cube && areaNonprogress(logic.checks[cube].area!);
         };
 
-        const gossipStonesBanned =
-            knownNoGossipStoneHintDistros.includes(hintDistro);
+        const gossipStoneUsed = doesHintDistroUseGossipStone[hintDistro] ?? _.stubTrue;
 
-        return (checkId: string, check: LogicalCheck) =>
-            // Loose crystal checks can be banned to not require picking them up
-            // in logic, but we want to allow marking them as collected.
-            (check.type !== 'loose_crystal' &&
-                (bannedChecks.has(check.name) ||
-                    areaNonprogress(logic.checks[checkId].area!))) ||
-            isExcessRelic(check) ||
-            isBannedChestViaCube(checkId) ||
-            isBannedCubeCheckViaChest(checkId, check) ||
-            (rupeesExcluded && check.type === 'rupee') ||
-            (banBeedle && check.type === 'beedle_shop') ||
-            (banGearShop && check.type === 'gear_shop') ||
-            (banPotionShop && check.type === 'potion_shop') ||
-            (!tadtoneSanity && check.type === 'tadtone') ||
-            (gossipStonesBanned && check.type === 'gossip_stone');
+        return (checkId: string) => {
+            const check = logic.checks[checkId];
+            return (
+                bannedChecks.has(check.name) ||
+                areaNonprogress(logic.checks[checkId].area!) ||
+                isExcessRelic(check) ||
+                isBannedChestViaCube(checkId) ||
+                isBannedCubeCheckViaChest(checkId, check) ||
+                (rupeesExcluded && check.type === 'rupee') ||
+                (banBeedle && check.type === 'beedle_shop') ||
+                (banGearShop && check.type === 'gear_shop') ||
+                (banPotionShop && check.type === 'potion_shop') ||
+                (!tadtoneSanity && check.type === 'tadtone') ||
+                (check.type === 'gossip_stone' && !gossipStoneUsed(checkId))
+            );
+        };
     },
 );
 
@@ -698,6 +698,7 @@ export const inTrickLogicBitsSelector = createSelector(
 const semiLogicBitsSelector = createSelector(
     [
         logicSelector,
+        isCheckBannedSelector,
         checkedChecksSelector,
         inventorySelector,
         inLogicBitsSelector,
@@ -810,8 +811,12 @@ export const areasSelector = createSelector(
         return _.compact(
             logic.hintRegions.map((area): HintRegion | undefined => {
                 const checks = logic.checksByHintRegion[area];
+                // Loose crystal checks can be banned to not require picking them up
+                // in logic, but we want to allow marking them as collected.
                 const progressChecks = checks.filter(
-                    (check) => !isCheckBanned(check, logic.checks[check]),
+                    (check) =>
+                        !isCheckBanned(check) ||
+                        logic.checks[check].type === 'loose_crystal',
                 );
 
                 const [extraChecks, regularChecks_] = _.partition(


### PR DESCRIPTION
* Adds a racing build (the actual build will probably have to be changed) to the default releases
* Loads default presets from the repo too so that the Presets button can load the default racing preset
* Hides gossip stones that are known to be irrelevant in the newest racing distros
* Changes semilogic behavior for banned loose gratitude crystals